### PR TITLE
Add Clerk to Integrated

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [Nextjs Auth0](https://github.com/auth0/nextjs-auth0) - Next.js SDK for signing in with Auth0
 - [Kinde Auth Nextjs](https://github.com/kinde-oss/kinde-auth-nextjs) - Kinde NextJS SDK - authentication for server rendered apps.
 - [Billing SDK](https://github.com/dodopayments/billingsdk) - Type-safe React billing and subscription components (pricing tables, usage meters, plan upgrade flows) built with Tailwind CSS and shadcn/ui.
+- [Clerk](https://github.com/clerk/javascript) - Auth and user management for Next.js with prebuilt components, middleware, and App Router support.
 
 ## E Commerce
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@
 - [Nextjs Auth0](https://github.com/auth0/nextjs-auth0) - Next.js SDK for signing in with Auth0
 - [Kinde Auth Nextjs](https://github.com/kinde-oss/kinde-auth-nextjs) - Kinde NextJS SDK - authentication for server rendered apps.
 - [Billing SDK](https://github.com/dodopayments/billingsdk) - Type-safe React billing and subscription components (pricing tables, usage meters, plan upgrade flows) built with Tailwind CSS and shadcn/ui.
-- [Clerk](https://github.com/clerk/javascript) - Auth and user management for Next.js with prebuilt components, middleware, and App Router support.
+- [Clerk](https://clerk.com/docs/quickstarts/nextjs) - Auth and user management for Next.js with prebuilt components, middleware, and App Router support.
 
 ## E Commerce
 


### PR DESCRIPTION
Adds [Clerk](https://clerk.com/docs/quickstarts/nextjs) to the Integrated section — auth and user management for Next.js with prebuilt components (`<SignIn />`, `<UserButton />`), middleware, and App Router support.

Several projects already listed here (Next Money, AI SaaS App, Travel Planner AI) use Clerk in their stacks, so a direct entry seemed useful.