### PR TITLE
docs: add Poszo Next.js Security Headers Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [Next Sanity](https://github.com/sanity-io/next-sanity) - Sanity.io toolkit for Next.js.
 - [Cookies Next](https://github.com/andreizanik/cookies-next) - Getting, setting and removing cookies on both client and server with next.js.
 - [NextStep](https://github.com/enszrlu/NextStep) - Lightweight onboarding library for Next.js.
+- [Poszo Next.js Security Headers Starter](https://github.com/poszothebuilder/poszo-nextjs-security-headers) - A free MIT-licensed starter with tested security headers, CSP guidance, validation commands, and rollback notes.
 
 ## Integrated
 


### PR DESCRIPTION
## Summary

Adds the free MIT-licensed Poszo Next.js Security Headers Starter to the Templates & Boilerplates section.

The resource includes tested baseline headers, CSP rollout guidance, validation commands, and rollback notes for Next.js deployments.

## Verification

- README-only change
- Public repository: https://github.com/poszothebuilder/poszo-nextjs-security-headers
- MIT license included
- No affiliate link or paid requirement