### PR TITLE
Add GuardLayer under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
 - [Next Sanity](https://github.com/sanity-io/next-sanity) - Sanity.io toolkit for Next.js.
 - [Cookies Next](https://github.com/andreizanik/cookies-next) - Getting, setting and removing cookies on both client and server with next.js.
 - [NextStep](https://github.com/enszrlu/NextStep) - Lightweight onboarding library for Next.js.
+- [GuardLayer](https://www.guardlayer.io) - Free static security scanner for Next.js + Supabase apps that flags exposed keys, missing RLS, over-permissive policies, and unprotected routes, with the exact fix.
 
 ## Integrated
 


### PR DESCRIPTION
GuardLayer is a free static security scanner for Next.js + Supabase apps — it flags exposed keys, missing RLS, over-permissive policies, and unprotected routes, each with the exact fix. Placed under Tools alongside the other dev utilities; happy to move it to SaaS if you'd prefer. Single-line entry, matched to the section's format.