### PR TITLE
Add MailKite SaaS Starter to SaaS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 - [Hikari](https://github.com/antoineross/Hikari) - A complete & open source Nextjs.14, Stripe and Supabase SaaS Starter Template using App Router.
 - [Firestarta](https://github.com/uixmat/firestarta) - Next.js SaaS boilerplate with NextAuth, Prisma, Supabase, Shadcn/ui & Lemon Squeezy Subscriptions.
 - [Next Money](https://github.com/virgoone/next-money) - Empower your next project with the stack of Next.js 14, Prisma, Supabase, Clerk Auth, Resend, React Email, Shadcn/ui, and Stripe.
+- [MailKite SaaS Starter](https://github.com/mailkite/saas-startup) - Production-ready Next.js 15 SaaS starter with self-contained auth (Google/GitHub OAuth + email/password — no auth vendor), Stripe subscriptions, teams, Postgres/Drizzle, and a dark-first shadcn/ui dashboard.
 
 ## App
 


### PR DESCRIPTION
Hi 👋

Added **[MailKite SaaS Starter](https://github.com/mailkite/saas-startup)** to the `## SaaS` section (appended at the end, matching the existing `- [Name](url) - Description.` format).

It's a production-ready, MIT-licensed Next.js 15 SaaS starter. What makes it a good fit for this list:

- **Self-contained auth** — Google/GitHub OAuth + email/password implemented in-app (JWT/sessions), so there's **no Clerk / Auth0 / Supabase-Auth account required**. Clone, add your own OAuth app, ship.
- **Stripe subscriptions + teams**, Postgres/Drizzle, and a dark-first shadcn/ui dashboard.
- Live demo: https://saas-startup.mailkite.dev

Happy to adjust the wording or placement if you'd prefer. Thanks for maintaining the list! 🙏