### PR TITLE
Add OopsSec Store to a new Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@
 - [Renoun](https://github.com/souporserious/renoun) - Documentation that matches the quality of your product.
 - [Opendocs](https://github.com/daltonmenezes/opendocs) - Next.js beautifully designed template that you can use for your projects for free with site, blog and docs support. Accessible. Customizable. Open Source with i18n support.
 
+## Security
+
+- [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) - A deliberately vulnerable e-commerce app built with the Next.js App Router, React, TypeScript and Prisma. 36 CTF challenges across web, API, auth, business logic, crypto, supply chain and AI/MCP, including real CVEs against this stack, each with a walkthrough explaining the vulnerability and its fix.
+
 ## Contributing
 
 Discover something fantastic, like a package, article, blog, video, or any other valuable resource? Feel free to contribute by sending a pull request! Your participation is highly appreciated. Thank you! ❤️


### PR DESCRIPTION
### What

Adds [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) to the list, under a new `Security` section.

> A deliberately vulnerable e-commerce app built with the Next.js App Router, React, TypeScript and Prisma. 36 CTF challenges across web, API, auth, business logic, crypto, supply chain and AI/MCP, including real CVEs against this stack, each with a walkthrough explaining the vulnerability and its fix.

### Why it belongs in awesome-nextjs

It is a security project, but the reason it is relevant here is that it is built *on* Next.js and teaches Next.js developers how their own apps break:

- Vulnerabilities are framed around Next.js-specific trust boundaries — the `NEXT_PUBLIC_` client-bundle trap, server components, middleware, and Prisma — not generic PHP-era examples.
- Several challenges reproduce published CVEs against this exact stack.
- Every challenge ships a walkthrough that goes from vulnerability to exploit to fix, so the takeaway is a secure pattern for your own App Router code.
- Runs in under a minute: `npx create-oss-store my-ctf-lab` or `docker run -p 127.0.0.1:3000:3000 leogra/oss-oopssec-store`.

MIT licensed, actively maintained, listed in the [OWASP Vulnerable Web Applications Directory](https://vwad.owasp.org/app/oopssec-store/).

### Note on the new section

The app is intentionally vulnerable, so listing it under `E Commerce` or `App` next to production-ready templates could mislead people into using it as a starter. A dedicated `Security` section makes the intent unambiguous and leaves room for future security-related entries. Happy to drop the section and move the entry under `App` instead if you prefer.
